### PR TITLE
chore: release v0.11.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.15](https://github.com/abusch/nu_plugin_semver/compare/v0.11.14...v0.11.15) - 2026-03-03
+
+### Other
+
+- bump dist
+- Upgrade to nushell 0.111
+- *(deps)* bump strum from 0.27.2 to 0.28.0
+- *(ci)* Upgrade cargo-dist
+
 ## [0.11.14](https://github.com/abusch/nu_plugin_semver/compare/v0.11.13...v0.11.14) - 2026-01-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_semver"
-version = "0.11.14"
+version = "0.11.15"
 dependencies = [
  "nu-plugin",
  "nu-plugin-test-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "nu_plugin_semver"
 readme = "README.md"
 repository = "https://github.com/abusch/nu_plugin_semver"
-version = "0.11.14"
+version = "0.11.15"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION



## 🤖 New release

* `nu_plugin_semver`: 0.11.14 -> 0.11.15

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.15](https://github.com/abusch/nu_plugin_semver/compare/v0.11.14...v0.11.15) - 2026-03-03

### Other

- bump dist
- Upgrade to nushell 0.111
- *(deps)* bump strum from 0.27.2 to 0.28.0
- *(ci)* Upgrade cargo-dist
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).