### PR TITLE
chore: release v0.11.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.16](https://github.com/abusch/nu_plugin_semver/compare/v0.11.15...v0.11.16) - 2026-05-03
+
+### Other
+
+- upgrade nushell to 0.112.2 + other deps
+
 ## [0.11.15](https://github.com/abusch/nu_plugin_semver/compare/v0.11.14...v0.11.15) - 2026-03-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_semver"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "nu-plugin",
  "nu-plugin-test-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "nu_plugin_semver"
 readme = "README.md"
 repository = "https://github.com/abusch/nu_plugin_semver"
-version = "0.11.15"
+version = "0.11.16"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION



## 🤖 New release

* `nu_plugin_semver`: 0.11.15 -> 0.11.16

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.16](https://github.com/abusch/nu_plugin_semver/compare/v0.11.15...v0.11.16) - 2026-05-03

### Other

- upgrade nushell to 0.112.2 + other deps
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).